### PR TITLE
Feature/#44/modify player

### DIFF
--- a/VirusBuster/src/ObjectClass.hpp
+++ b/VirusBuster/src/ObjectClass.hpp
@@ -62,6 +62,8 @@ private:
 
 	int BulletType;
 
+	double shot_time;
+
 public:
 	Player();
 	~Player();
@@ -70,6 +72,7 @@ public:
 	void rotate();
 	void SelectBullet();
 	BulletTemplate* Shoot();
+	bool check_shotcool();
 
 	void debug();
 };

--- a/VirusBuster/src/Player.cpp
+++ b/VirusBuster/src/Player.cpp
@@ -63,12 +63,12 @@ void Player::SelectBullet() {
 	if (Key4.down())
 		BulletType = 4;
 
-	if (KeyR.down()) {
+	if (KeyR.down() || KeyUp.down()) {
 		BulletType++;
 		if (BulletType > max_type)
 			BulletType = 1;
 	}
-	if (KeyE.down()) {
+	if (KeyE.down() || KeyDown.down()) {
 		BulletType--;
 		if (BulletType < 1)
 			BulletType = max_type;

--- a/VirusBuster/src/Player.cpp
+++ b/VirusBuster/src/Player.cpp
@@ -1,7 +1,7 @@
 ﻿#include"ObjectClass.hpp"
 
 Player::Player() {
-	position = Scene::Center();
+	position = Vec2((Scene::Width()/2), Scene::Height());
 	//angle = Math::Pi / 2;
 	angle = 0;
 	vecR = OffsetCircular(position, 400, angle);

--- a/VirusBuster/src/Player.cpp
+++ b/VirusBuster/src/Player.cpp
@@ -32,8 +32,8 @@ void Player::rotate() {
 			angle += R;
 		}
 
-		if (angle > 2 * Math::Pi)
-			angle -= 2 * Math::Pi;
+		if (angle > Math::Pi / 2)
+			angle = Math::Pi / 2;
 	}
 	if (KeyLeft.pressed()) {
 		if (KeyShift.pressed()) {
@@ -42,8 +42,8 @@ void Player::rotate() {
 		else {
 			angle -= R;
 		}
-		if (angle < 0)
-			angle += 2 * Math::Pi;
+		if (angle < (-1) * Math::Pi / 2)
+			angle = (-1) * Math::Pi / 2;
 	}
 
 	vecR = OffsetCircular(position, 400, angle);

--- a/VirusBuster/src/Player.cpp
+++ b/VirusBuster/src/Player.cpp
@@ -10,6 +10,8 @@ Player::Player() {
 	shot_line = Line(position.x, position.y, vecR.x, vecR.y);
 
 	BulletType = 1;
+
+	shot_time = 0;
 }
 
 Player::~Player() {
@@ -77,6 +79,17 @@ void Player::SelectBullet() {
 
 BulletTemplate* Player::Shoot() {
 	return (BulletTemplate*)new bullet_norm(RectF(Arg::center(position), 5), angle);
+}
+
+bool Player::check_shotcool() {
+	static constexpr double shot_cool = 0.2;
+
+	if ((Scene::Time() - shot_time) > shot_cool) {
+		shot_time = Scene::Time();
+		return true;
+	}
+	else
+		return false;
 }
 
 void Player::debug() {

--- a/VirusBuster/src/Stage.cpp
+++ b/VirusBuster/src/Stage.cpp
@@ -12,7 +12,9 @@ void Stage::update() {
 	player.SelectBullet();
 
 	if (KeySpace.pressed()) {
-		bullets << player.Shoot();
+		if (player.check_shotcool()) {
+			bullets << player.Shoot();
+		}
 	}
 	for (BulletTemplate* b : bullets) {
 		b->move();

--- a/VirusBuster/src/Stage.cpp
+++ b/VirusBuster/src/Stage.cpp
@@ -11,10 +11,8 @@ void Stage::update() {
 	player.rotate();
 	player.SelectBullet();
 
-	if (KeySpace.pressed()) {
-		if (player.check_shotcool()) {
-			bullets << player.Shoot();
-		}
+	if (KeySpace.pressed() && player.check_shotcool()) {
+		bullets << player.Shoot();
 	}
 	for (BulletTemplate* b : bullets) {
 		b->move();

--- a/VirusBuster/src/Stage.cpp
+++ b/VirusBuster/src/Stage.cpp
@@ -11,7 +11,7 @@ void Stage::update() {
 	player.rotate();
 	player.SelectBullet();
 
-	if (KeySpace.down()) {
+	if (KeySpace.pressed()) {
 		bullets << player.Shoot();
 	}
 	for (BulletTemplate* b : bullets) {


### PR DESCRIPTION
## Issue 番号
Close #44 

## 変更内容

1. Space長押しで弾を発射できるようにしました。
2. [↑][↓]キーで弾丸のスロットを１つ変更できるようにしました。
3. プレイヤーの位置を調整。同時に回転の角度を制限しました。
4. １がそのままだとプレーヤーがあまりにも強すぎたので弾丸発射までのクールタイムを設けました。
