### PR TITLE
プレーヤーの角度及び弾丸の反射関係の調整

### DIFF
--- a/VirusBuster/src/BulletTemplate.cpp
+++ b/VirusBuster/src/BulletTemplate.cpp
@@ -17,11 +17,14 @@ void BulletTemplate::move() {
 }
 
 bool BulletTemplate::remove(Array<EnemyTemplate*> enemies) {
+	static constexpr double rm_area = 10;	//削除しない範囲を拡大させるための変数
 	bool flg = false;
-	if (0 > Body.center().x || Body.center().x > Scene::Width() ||
+
+	if (-rm_area > Body.center().x || Body.center().x > Scene::Width() + rm_area ||
 		0 > Body.center().y || Body.center().y > Scene::Height()) {
 		flg = true;
-	} else if (reflectCount <= 0) {
+	}
+	else if (reflectCount <= 0) {
 		flg = true;
 	}
 	for (EnemyTemplate* enemy : enemies) {

--- a/VirusBuster/src/BulletTemplate.cpp
+++ b/VirusBuster/src/BulletTemplate.cpp
@@ -17,22 +17,22 @@ void BulletTemplate::move() {
 }
 
 bool BulletTemplate::remove(Array<EnemyTemplate*> enemies) {
-	static constexpr double rm_area = 10;	//削除しない範囲を拡大させるための変数
-	bool flg = false;
+	static constexpr double expand_rm_area = 10;	//削除しない範囲を拡大させるための変数
+	bool is_removed = false;
 
-	if (-rm_area > Body.center().x || Body.center().x > Scene::Width() + rm_area ||
+	if (-expand_rm_area > Body.center().x || Body.center().x > Scene::Width() + expand_rm_area ||
 		0 > Body.center().y || Body.center().y > Scene::Height()) {
-		flg = true;
+		is_removed = true;
 	}
 	else if (reflectCount <= 0) {
-		flg = true;
+		is_removed = true;
 	}
 	for (EnemyTemplate* enemy : enemies) {
 		if (Body.intersects(enemy->Body)) {
 			enemy->damaged(damage);
 
-			flg=true;
+			is_removed=true;
 		}
 	}
-	return flg;
+	return is_removed;
 }

--- a/VirusBuster/src/Player.cpp
+++ b/VirusBuster/src/Player.cpp
@@ -41,8 +41,8 @@ void Player::rotate() {
 		else {
 			angle -= R;
 		}
-		if (angle < (-1) * Math::Pi)
-			angle = (-1) * Math::Pi;
+		if (angle < -Math::Pi)
+			angle = -Math::Pi;
 	}
 }
 

--- a/VirusBuster/src/Player.cpp
+++ b/VirusBuster/src/Player.cpp
@@ -31,8 +31,8 @@ void Player::rotate() {
 			angle += R;
 		}
 
-		if (angle > Math::Pi / 2)
-			angle = Math::Pi / 2;
+		if (angle > 0)
+			angle = 0;
 	}
 	if (KeyLeft.pressed()) {
 		if (KeyShift.pressed()) {
@@ -41,8 +41,8 @@ void Player::rotate() {
 		else {
 			angle -= R;
 		}
-		if (angle < (-1) * Math::Pi / 2)
-			angle = (-1) * Math::Pi / 2;
+		if (angle < (-1) * Math::Pi)
+			angle = (-1) * Math::Pi;
 	}
 }
 

--- a/VirusBuster/src/bullet_norm.cpp
+++ b/VirusBuster/src/bullet_norm.cpp
@@ -15,13 +15,14 @@ void bullet_norm::move() {
 	if (0 >= Body.x || Body.x >= Scene::Width()) {
 		reflectCount--;
 		angle=Vec2(sin(angle), cos(angle)).getAngle();
-		if (0 >= Body.x) {
+		/*if (0 >= Body.x) {
 			Body.x *= -1;
-		} else {
-			Body.x = 2.0 * Scene::Width() - Body.x;
 		}
+		else {
+			Body.x = 2.0 * Scene::Width() - Body.x;
+		}*/
 	}
-	if (0 >= Body.y || Body.y >= Scene::Height()) {
+	/*if (0 >= Body.y || Body.y >= Scene::Height()) {
 		reflectCount--;
 		angle = Vec2(-sin(angle), -cos(angle)).getAngle();
 		if (0 >= Body.y) {
@@ -29,7 +30,7 @@ void bullet_norm::move() {
 		} else {
 			Body.y = 2.0 * Scene::Height() - Body.y;
 		}
-	}
+	}*/
 }
 
 void bullet_norm::draw() {

--- a/VirusBuster/src/bullet_norm.cpp
+++ b/VirusBuster/src/bullet_norm.cpp
@@ -15,22 +15,7 @@ void bullet_norm::move() {
 	if (0 >= Body.x || Body.x >= Scene::Width()) {
 		reflectCount--;
 		angle=Vec2(sin(angle), cos(angle)).getAngle();
-		/*if (0 >= Body.x) {
-			Body.x *= -1;
-		}
-		else {
-			Body.x = 2.0 * Scene::Width() - Body.x;
-		}*/
 	}
-	/*if (0 >= Body.y || Body.y >= Scene::Height()) {
-		reflectCount--;
-		angle = Vec2(-sin(angle), -cos(angle)).getAngle();
-		if (0 >= Body.y) {
-			Body.y *= -1;
-		} else {
-			Body.y = 2.0 * Scene::Height() - Body.y;
-		}
-	}*/
 }
 
 void bullet_norm::draw() {

--- a/VirusBuster/src/bullet_norm.cpp
+++ b/VirusBuster/src/bullet_norm.cpp
@@ -15,21 +15,10 @@ void bullet_norm::move() {
 	if (0 >= Body.x || Body.x >= Scene::Width()) {
 		reflectCount--;
 		angle=Vec2(sin(angle), cos(angle)).getAngle();
-		/*if (0 >= Body.x) {
-			Body.x *= -1;
-		}
-		else {
-			Body.x = 2.0 * Scene::Width() - Body.x;
-		}*/
 	}
 	/*if (0 >= Body.y || Body.y >= Scene::Height()) {
 		reflectCount--;
 		angle = Vec2(-sin(angle), -cos(angle)).getAngle();
-		if (0 >= Body.y) {
-			Body.y *= -1;
-		} else {
-			Body.y = 2.0 * Scene::Height() - Body.y;
-		}
 	}*/
 }
 


### PR DESCRIPTION
## Issue 番号
Close #50 

## 変更内容

1. プレーヤーの角度関係の変化に伴って回転制限を調節しました
2. 弾丸の反射がおかしなことになっていたので、一部修正しました
3. ２に伴って、弾丸が削除される座標を少し広めに設けました

