### PR TITLE
inside関数の作成

### DIFF
--- a/VirusBuster/src/Basic.hpp
+++ b/VirusBuster/src/Basic.hpp
@@ -13,7 +13,7 @@ struct GameData {
 
 using App = SceneManager<State, GameData>;
 
-bool is_inside(double x, double y, double w, double h, RectF body) {
+bool is_inside(double x = 0, double y = 0, double w = Scene::Width(), double h = Scene::Height(), RectF body) {
 	if (x <= body.center().x or body.center().x <= x + w or
 		y <= body.center().y or body.center().y <= y + h) {
 		return true;

--- a/VirusBuster/src/Basic.hpp
+++ b/VirusBuster/src/Basic.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 # include <Siv3D.hpp> // OpenSiv3D v0.6.3
 
 enum class State {
@@ -12,3 +12,11 @@ struct GameData {
 };
 
 using App = SceneManager<State, GameData>;
+
+bool is_inside(double x, double y, double w, double h, RectF body) {
+	if (x <= body.center().x or body.center().x <= x + w or
+		y <= body.center().y or body.center().y <= y + h) {
+		return true;
+	}
+	return false;
+}

--- a/VirusBuster/src/Basic.hpp
+++ b/VirusBuster/src/Basic.hpp
@@ -13,4 +13,5 @@ struct GameData {
 
 using App = SceneManager<State, GameData>;
 
-bool is_inside(RectF body, double x = 0, double y = 0, double x_ = Scene::Width(), double y_ = Scene::Height());
+//指定した範囲内にbodyがあるか調べる関数
+bool is_inside(RectF body, double x = 0, double y = 0, double x_ = Scene::Width(), double h = Scene::Height());

--- a/VirusBuster/src/Basic.hpp
+++ b/VirusBuster/src/Basic.hpp
@@ -13,10 +13,4 @@ struct GameData {
 
 using App = SceneManager<State, GameData>;
 
-bool is_inside(double x = 0, double y = 0, double w = Scene::Width(), double h = Scene::Height(), RectF body) {
-	if (x <= body.center().x or body.center().x <= x + w or
-		y <= body.center().y or body.center().y <= y + h) {
-		return true;
-	}
-	return false;
-}
+bool is_inside(RectF body, double x = 0, double y = 0, double w = Scene::Width(), double h = Scene::Height());

--- a/VirusBuster/src/Basic.hpp
+++ b/VirusBuster/src/Basic.hpp
@@ -13,4 +13,4 @@ struct GameData {
 
 using App = SceneManager<State, GameData>;
 
-bool is_inside(RectF body, double x = 0, double y = 0, double w = Scene::Width(), double h = Scene::Height());
+bool is_inside(RectF body, double x = 0, double y = 0, double x_ = Scene::Width(), double y_ = Scene::Height());

--- a/VirusBuster/src/BulletTemplate.cpp
+++ b/VirusBuster/src/BulletTemplate.cpp
@@ -20,8 +20,7 @@ bool BulletTemplate::remove(Array<EnemyTemplate*> enemies) {
 	static constexpr double expand_rm_area = 10;	//削除しない範囲を拡大させるための変数
 	bool is_removed = false;
 
-	if (-expand_rm_area > Body.center().x || Body.center().x > Scene::Width() + expand_rm_area ||
-		0 > Body.center().y || Body.center().y > Scene::Height()) {
+	if (!is_inside(Body, -expand_rm_area, -expand_rm_area, Scene::Width() + expand_rm_area, Scene::Height() + expand_rm_area)) {
 		is_removed = true;
 	}
 	else if (reflectCount <= 0) {

--- a/VirusBuster/src/Function.cpp
+++ b/VirusBuster/src/Function.cpp
@@ -1,0 +1,9 @@
+﻿#include"Basic.hpp"
+
+bool is_inside(RectF body, double x1, double y1, double x2, double y2) {
+	if (x1 <= body.center().x or body.center().x <= x2 or
+		y1 <= body.center().y or body.center().y <= y2) {
+		return true;
+	}
+	return false;
+}

--- a/VirusBuster/src/Function.cpp
+++ b/VirusBuster/src/Function.cpp
@@ -1,9 +1,0 @@
-﻿#include"Basic.hpp"
-
-bool is_inside(RectF body, double x1, double y1, double x2, double y2) {
-	if (x1 <= body.center().x or body.center().x <= x2 or
-		y1 <= body.center().y or body.center().y <= y2) {
-		return true;
-	}
-	return false;
-}

--- a/VirusBuster/src/Stage.cpp
+++ b/VirusBuster/src/Stage.cpp
@@ -43,5 +43,14 @@ void Stage::draw() const {
 void Stage::debug() {
 	ClearPrint();
 	Print << U"ここはゲーム本編";
+	Print << Scene::Time();
 	player.debug();
+}
+
+bool is_inside(RectF body, double x1, double y1, double x2, double y2) {
+	if (x1 <= body.center().x or body.center().x <= x2 or
+		y1 <= body.center().y or body.center().y <= y2) {
+		return true;
+	}
+	return false;
 }

--- a/VirusBuster/src/bullet_norm.cpp
+++ b/VirusBuster/src/bullet_norm.cpp
@@ -12,6 +12,8 @@ void bullet_norm::move() {
 
 	Body.x += speed * cos(angle);
 	Body.y += speed * sin(angle);
+
+	//y軸で反射しないのでここではinside()は使いません
 	if (0 >= Body.x || Body.x >= Scene::Width()) {
 		reflectCount--;
 		angle=Vec2(sin(angle), cos(angle)).getAngle();


### PR DESCRIPTION
## Issue 番号
#50 

## 変更内容
Basic.hpp内にinsideという関数を定義しました。
上記関数は指定した範囲に引数の図形が収まっているか判定する関数です。
具体的な引数は

1. 当たり判定部分（RectF）
2. 左ｘ座標
3. 上ｙ座標
4. 右ｘ座標
5. 下ｙ座標

の５つであり、具体的な使用方法としては

1. 引数必須
2. デフォルトで０
3. デフォルトで０
4. デフォルトでScene::Width
5. デフォルトでScene::Height

その他、細かいデバッグ表示やコメント文なども追加しました